### PR TITLE
[ci skip] removing user @goanpeca

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -45,6 +45,5 @@ about:
 extra:
   recipe-maintainers:
     - conda-forge/napari
-    - goanpeca
     - psobolewskiPhD
     - tdmorello


### PR DESCRIPTION
Manually removing @goanpeca from the maintainers list because the conda-forge-admin bot has not processed the request.

Closes #7